### PR TITLE
Enable testing without UI

### DIFF
--- a/src/OSRS Bot COLOR.py
+++ b/src/OSRS Bot COLOR.py
@@ -1,4 +1,4 @@
-from controller.bot_controller import BotController
+from controller.bot_controller import BotController, MockBotController
 from model import *
 from typing import List
 from view import *
@@ -16,9 +16,12 @@ class App(customtkinter.CTk):
     HEIGHT = 520
     DEFAULT_GRAY = ("gray50", "gray30")
 
-    def __init__(self):  # sourcery skip: merge-list-append, move-assign-in-block
+    def __init__(self, test: bool = False):
         super().__init__()
-
+        if not test:
+            self.build_ui()
+    
+    def build_ui(self):  # sourcery skip: merge-list-append, move-assign-in-block
         self.title("OSRS Bot COLOR")
         self.geometry(f"{App.WIDTH}x{App.HEIGHT}")
         self.update()
@@ -256,8 +259,21 @@ class App(customtkinter.CTk):
 
     def start(self):
         self.mainloop()
+    
+    def test(self, bot: Bot):
+        bot.set_controller(MockBotController(bot))
+        bot.set_status(BotStatus.RUNNING)
+        time.sleep(1)
+        bot.main_loop()
 
 
 if __name__ == "__main__":
-    app = App()
-    app.start()
+    # To test a bot without the GUI, address the comments for each line below.
+    app = App()  # Add the "test=True" argument to the App constructor call.
+    app.start()  # Comment out this line.
+    #app.test(Bot()) # Uncomment this line and replace argument with your bot's instance.
+
+    # Note: when testing a bot, ensure all of its options have set default values
+    # in its init() function.
+    #   E.g., self.running_time = 5
+    # Stop your bot by holding 'ESC'.

--- a/src/controller/bot_controller.py
+++ b/src/controller/bot_controller.py
@@ -94,3 +94,43 @@ class BotController(object):
         else:
             self.view.frame_info.setup(title="", description="")
         self.clear_log()
+
+
+class MockBotController(object):
+
+    def __init__(self, model):
+        '''
+        A mock controller for testing purposes. Allows you to run a bot without a UI.
+        Usage:
+            # Within your Bot's class...
+            if __name__ == '__main__':
+                bot = MyBot()
+                bot.set_controller(MockBotController(bot))
+                time.sleep(2)
+                bot.main_loop()
+        '''
+        self.model: Bot = model
+
+    def update_status(self):
+        '''
+        Called from model. Tells view to update status
+        '''
+        print(f"Updating status on UI to: {self.model.status}")
+
+    def update_progress(self):
+        '''
+        Called from model. Tells view to update progress.
+        '''
+        print(f"Updating progress bar on view to: {self.model.progress * 100}")  # might have the math wrong here
+
+    def update_log(self, msg: str, overwrite: bool = False):
+        '''
+        Called from model. Tells view to update log.
+        '''
+        print(f"Send log msg to UI: {msg}")
+
+    def clear_log(self):
+        '''
+        Called from model. Tells view to clear log.
+        '''
+        print("--- Clearing log ---")

--- a/src/model/osnr/mining.py
+++ b/src/model/osnr/mining.py
@@ -1,6 +1,3 @@
-'''
-Trains Runecrafting via Astral Runes.
-'''
 from model.bot import BotStatus
 from model.osnr.osnr_bot import OSNRBot
 import pyautogui as pag
@@ -14,7 +11,8 @@ class OSNRMining(OSNRBot):
                        "between some rocks and mark (shift + right-click) the ones you want to mine. Your character " +
                        "must remain stationary.")
         super().__init__(title=title, description=description)
-        self.running_time = 0
+        self.running_time = 2
+        self.logout_on_friends = False
 
     def create_options(self):
         self.options_builder.add_slider_option("running_time", "How long to run (minutes)?", 1, 500)


### PR DESCRIPTION
Resolves #23 

Added support for testing a Bot's main_loop without the GUI.

@Travis-Barton I think this is the best solution I could come up with. Unfortunately, it's not possible to do this by running the Bot's .py file as top-level since Python importing is cruel. Bots are treated as modules, so it was never really an option.

The workaround is to use `OSRS Bot COLOR.py`, and just tell it to enter "test mode". Check out the `if __name__ == "__main__":` conditional at the bottom of the file to see how I did it. All you need to do is touch 3 lines of code to get one-click testing enabled.