### PR TITLE
Bot control keyboard shortcut improvements

### DIFF
--- a/src/view/info_frame.py
+++ b/src/view/info_frame.py
@@ -192,11 +192,12 @@ class InfoFrame(customtkinter.CTkFrame):
         if self.pressed:
             return
         if key == keyboard.Key.ctrl_l:
+            self.pressed = True
             if self.status == "running":
                 self.controller.stop()
             elif self.status == "stopped":
                 self.controller.play()
-        self.pressed = True
+                self.pressed = False
 
     def __on_release(self, key):
         self.pressed = False

--- a/src/view/info_frame.py
+++ b/src/view/info_frame.py
@@ -12,7 +12,7 @@ class InfoFrame(customtkinter.CTkFrame):
     listener = None
     pressed = False
     current_keys = set()
-    combination_keys = {keyboard.Key.ctrl_l, keyboard.Key.shift, keyboard.Key.space}
+    combination_keys = {keyboard.Key.shift, keyboard.Key.enter}
     status = "stopped"
 
     def __init__(self, parent, title, info):  # sourcery skip: merge-nested-ifs
@@ -99,7 +99,8 @@ class InfoFrame(customtkinter.CTkFrame):
             image=self.img_play,
             command=self.play_btn_clicked,
         )
-        self.btn_play.bind("<Enter>", lambda event: event.widget.configure(text="Ctl + Shft + Space"))
+        # TODO: Replace with function that replaces text with keybind from settings
+        self.btn_play.bind("<Enter>", lambda event: event.widget.configure(text="↑ + ↵"))
         self.btn_play.bind("<Leave>", lambda event: event.widget.configure(text="Play"))
         self.btn_play.grid(row=1, column=0, pady=(0, 15), sticky="nsew")
 
@@ -112,7 +113,8 @@ class InfoFrame(customtkinter.CTkFrame):
             image=self.img_stop,
             command=self.stop_btn_clicked,
         )
-        self.btn_stop.bind("<Enter>", lambda event: event.widget.configure(text="Ctl + Shft + Space"))
+        # TODO: Replace with function that replaces text with keybind from settings
+        self.btn_stop.bind("<Enter>", lambda event: event.widget.configure(text="↑ + ↵"))
         self.btn_stop.bind("<Leave>", lambda event: event.widget.configure(text="Stop"))
 
         self.btn_options = customtkinter.CTkButton(

--- a/src/view/info_frame.py
+++ b/src/view/info_frame.py
@@ -11,6 +11,8 @@ from utilities.game_launcher import Launchable
 class InfoFrame(customtkinter.CTkFrame):
     listener = None
     pressed = False
+    current_keys = set()
+    combination_keys = {keyboard.Key.ctrl_l, keyboard.Key.shift, keyboard.Key.space}
     status = "stopped"
 
     def __init__(self, parent, title, info):  # sourcery skip: merge-nested-ifs
@@ -92,22 +94,26 @@ class InfoFrame(customtkinter.CTkFrame):
 
         self.btn_play = customtkinter.CTkButton(
             master=self.btn_frame,
-            text="Play [Ctrl]",
+            text="Play",
             text_color="white",
             image=self.img_play,
             command=self.play_btn_clicked,
         )
+        self.btn_play.bind("<Enter>", lambda event: event.widget.configure(text="Ctl + Shft + Space"))
+        self.btn_play.bind("<Leave>", lambda event: event.widget.configure(text="Play"))
         self.btn_play.grid(row=1, column=0, pady=(0, 15), sticky="nsew")
 
         self.btn_stop = customtkinter.CTkButton(
             master=self.btn_frame,
-            text="Stop [Ctrl]",
+            text="Stop",
             text_color="white",
             fg_color="#910101",
             hover_color="#690101",
             image=self.img_stop,
             command=self.stop_btn_clicked,
         )
+        self.btn_stop.bind("<Enter>", lambda event: event.widget.configure(text="Ctl + Shft + Space"))
+        self.btn_stop.bind("<Leave>", lambda event: event.widget.configure(text="Stop"))
 
         self.btn_options = customtkinter.CTkButton(
             master=self.btn_frame,
@@ -189,18 +195,20 @@ class InfoFrame(customtkinter.CTkFrame):
         self.listener.stop()
 
     def __on_press(self, key):
-        if self.pressed:
-            return
-        if key == keyboard.Key.ctrl_l:
+        self.current_keys.add(key)
+        if all(k in self.current_keys for k in self.combination_keys) and not self.pressed:
             self.pressed = True
             if self.status == "running":
                 self.controller.stop()
             elif self.status == "stopped":
                 self.controller.play()
                 self.pressed = False
+                self.current_keys.clear()
 
     def __on_release(self, key):
-        self.pressed = False
+        self.current_keys.discard(key)
+        if all(k not in self.current_keys for k in self.combination_keys):
+            self.pressed = False
 
     # ---- Status Handlers ----
     def update_status_running(self):


### PR DESCRIPTION
This PR includes a fix for keyboard shortcuts not triggering the bot start/stop immediately. It also changes the current `Ctrl` keybind to a key combination instead.

TODO: The key combination is up for debate. Also, the way the combination is displayed on the button needs to be replaced. Right now, it takes up too much space and resizes the button. A good alternative would be to set a max width on the button and replace the text with an image, or proper symbols that are compatible with Tkinter and other operating systems.