### PR TITLE
Potential fix for false-positive antivirus trigger

### DIFF
--- a/src/utilities/settings.py
+++ b/src/utilities/settings.py
@@ -41,26 +41,28 @@ default_keybind = {keyboard.Key.shift, keyboard.Key.enter}
 
 
 def keybind_to_text(current_keys):
-    keys_to_display = []
+    hotkeys = []
     for key in current_keys:
-        if key == keyboard.Key.enter:
-            keys_to_display.append("↵")
-        elif key == keyboard.Key.space:
-            keys_to_display.append("␣")
-        elif key in [keyboard.Key.ctrl, keyboard.Key.ctrl_l, keyboard.Key.ctrl_r]:
-            keys_to_display.append("^")
-        elif key in [keyboard.Key.alt, keyboard.Key.alt_l, keyboard.Key.alt_r]:
-            keys_to_display.append("⌥")
-        elif key in [keyboard.Key.shift, keyboard.Key.shift_l, keyboard.Key.shift_r]:
-            keys_to_display.append("⇧")
-        elif key in [keyboard.Key.cmd, keyboard.Key.cmd_l, keyboard.Key.cmd_r]:
-            keys_to_display.append("⌘")
-        elif key in [keyboard.Key.caps_lock]:
-            keys_to_display.append("⇪")
-        elif key in [keyboard.Key.tab]:
-            keys_to_display.append("⇥")
-        elif key in [keyboard.Key.backspace]:
-            keys_to_display.append("⌫")
-        else:
-            keys_to_display.append(key)
-    return " + ".join([str(key).replace("'", "") for key in keys_to_display])
+        match key:
+            case keyboard.Key.enter:
+                hotkeys.append("↵")
+            case keyboard.Key.space:
+                hotkeys.append("␣")
+            case keyboard.Key.ctrl | keyboard.Key.ctrl_l | keyboard.Key.ctrl_r:
+                hotkeys.append("^")
+            case keyboard.Key.alt | keyboard.Key.alt_l | keyboard.Key.alt_r:
+                hotkeys.append("⌥")
+            case keyboard.Key.shift | keyboard.Key.shift_l | keyboard.Key.shift_r:
+                hotkeys.append("⇧")
+            case keyboard.Key.cmd | keyboard.Key.cmd_l | keyboard.Key.cmd_r:
+                hotkeys.append("⌘")
+            case keyboard.Key.caps_lock:
+                hotkeys.append("⇪")
+            case keyboard.Key.tab:
+                hotkeys.append("⇥")
+            case keyboard.Key.backspace:
+                hotkeys.append("⌫")
+            case _:
+                hotkeys.append(key)
+
+    return " + ".join(map(str, hotkeys)).replace("'", "")


### PR DESCRIPTION
Fixes OSR-36

Fixed a certain issue which I cannot easily describe here as the owners of the OS and github are the same company. The root cause is probably non-obfuscated code that has flagged filenames on github, giving the company data to do some pattern recognition. A line with triggering keywords in the changed function matches what was already out there.

Before:
![image](https://user-images.githubusercontent.com/62894711/216563342-a09ed3b4-0a8b-4cd6-a939-a203d88ed6df.png)

After:
![image](https://user-images.githubusercontent.com/62894711/216559827-4eb185f4-7400-401d-b78f-e787ef7fc0b9.png)

The pull request aims to change the area that was wrongfully picked up by the OS's scan tool to be different than what is out there.
