### PR TITLE
Removes pag mouse calls and uses Mouse class

### DIFF
--- a/src/model/bot.py
+++ b/src/model/bot.py
@@ -284,7 +284,7 @@ class Bot(ABC):
                 offsetBoundaryX=40,
                 tween=pytweening.easeInOutQuad,
             )
-            pag.click()
+            self.mouse.click()
         pag.keyUp("shift")
 
     def friends_nearby(self) -> bool:
@@ -456,7 +456,7 @@ class Bot(ABC):
     def __compass_right_click(self, msg, rel_y):
         self.log_msg(msg)
         self.mouse.move_to(self.win.compass_orb.random_point())
-        pag.rightClick()
+        self.mouse.right_click()
         self.mouse.move_rel(0, rel_y, 5, 2)
         self.mouse.click()
 
@@ -513,7 +513,7 @@ class Bot(ABC):
         self.log_msg(f"Toggling auto retaliate {state}...")
         # click the combat tab
         self.mouse.move_to(self.win.cp_tabs[0].random_point())
-        pag.click()
+        self.mouse.click()
         time.sleep(0.5)
 
         if toggle_on:


### PR DESCRIPTION
Fixes OSR-54

Removes  calls previously using pag.click and pag.rightclick to self.mouse.click and self.mouse.right_click. Done in an effort to keep consistency.  