### PR TITLE
Add Morg API method to get first item occurrences and distance calculation to geometry.py

### DIFF
--- a/src/utilities/api/morg_http_client.py
+++ b/src/utilities/api/morg_http_client.py
@@ -334,6 +334,31 @@ class MorgHTTPSocket:
         elif isinstance(item_id, list):
             return [i for i, inventory_slot in enumerate(data) if inventory_slot["id"] in item_id]
 
+    def get_first_indice(self, item_id: Union[List[int], int]) -> Union[int, List[int]]:
+        """
+        For the given item ID(s), returns the first inventory slot index that the item exists in.
+        e.g. [1, 1, 2, 3, 3, 3, 4, 4, 4, 4] -> [0, 2, 3, 6]
+        Args:
+            item_id: The item ID to search for (an single ID, or list of IDs).
+        Returns:
+            The first inventory slot index that the item exists in for each unique item ID.
+            If a single item ID is provided, returns an integer.
+            If no matching item ID is found, returns -1.
+        """
+        data = self.__do_get(endpoint=self.inv_endpoint)
+        if isinstance(item_id, int):
+            return next((i for i, inventory_slot in enumerate(data) if inventory_slot["id"] == item_id), -1)
+
+        elif isinstance(item_id, list):
+            first_occurrences = {}
+
+            for i, inventory_slot in enumerate(data):
+                item_id_in_slot = inventory_slot["id"]
+                if item_id_in_slot not in first_occurrences and item_id_in_slot in item_id:
+                    first_occurrences[item_id_in_slot] = i
+
+            return list(first_occurrences.values())        
+        
     def get_inv_item_stack_amount(self, item_id: Union[int, List[int]]) -> int:
         """
         For the given item ID, returns the total amount of that item in your inventory.

--- a/src/utilities/geometry.py
+++ b/src/utilities/geometry.py
@@ -132,6 +132,14 @@ class Rectangle:
         """
         return Point(self.left, self.top)
 
+    def get_center_left(self) -> Point:
+        """
+        Gets the center left point of the rectangle.
+        Returns:
+            A Point representing the center left of the rectangle.
+        """
+        return Point(self.left, self.top + self.height // 2)
+
     def get_top_right(self) -> Point:
         """
         Gets the top right point of the rectangle.
@@ -225,6 +233,19 @@ class RuneLiteObject:
         center: Point = self.center()
         rect_center: Point = self.rect.get_center()
         return math.dist([center.x, center.y], [rect_center.x, rect_center.y])
+    
+    def distance_from_rect_left(self) -> float:
+        """
+        Gets the distance between the object and it's Rectangle parent left edge.
+        Useful for sorting lists of RuneLiteObjects.
+        Returns:
+            The distance from the point to the center of the object.
+        Note:
+            Only use this if you're sorting a list of RuneLiteObjects that are contained in the same Rectangle.
+        """
+        left: Point = self.center()
+        rect_left: Point = self.rect.get_center_left()
+        return math.dist([left.x, left.y], [rect_left.x, rect_left.y])
 
     def random_point(self, custom_seeds: List[List[int]] = None) -> Point:
         """

--- a/src/utilities/geometry.py
+++ b/src/utilities/geometry.py
@@ -243,9 +243,9 @@ class RuneLiteObject:
         Note:
             Only use this if you're sorting a list of RuneLiteObjects that are contained in the same Rectangle.
         """
-        left: Point = self.center()
+        center: Point = self.center()
         rect_left: Point = self.rect.get_center_left()
-        return math.dist([left.x, left.y], [rect_left.x, rect_left.y])
+        return math.dist([center.x, center.y], [rect_left.x, rect_left.y])
 
     def random_point(self, custom_seeds: List[List[int]] = None) -> Point:
         """


### PR DESCRIPTION
        For the given item ID(s), returns the first inventory slot index that the item exists in.
        e.g. [1, 1, 2, 3, 3, 3, 4, 4, 4, 4] -> [0, 2, 3, 6]
        Args:
            item_id: The item ID to search for (an single ID, or list of IDs).
        Returns:
            The first inventory slot index that the item exists in for each unique item ID.
            If a single item ID is provided, returns an integer.
            If no matching item ID is found, returns -1.