### PR TITLE
Adding Pushbullet integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pynput==1.7.6
 pywinctl==0.0.42
 requests==2.28.1
 simplejson==3.17.6
+pushbullet-python==1.7.0

--- a/src/OSBC.py
+++ b/src/OSBC.py
@@ -196,7 +196,7 @@ class App(customtkinter.CTk):
     # ============ Button Handlers ============
     def __on_settings_clicked(self):
         window = customtkinter.CTkToplevel(master=self)
-        window.geometry("540x287")
+        window.geometry("540x400")
         window.title("Settings")
         view = SettingsView(parent=window)
         view.pack(side="top", fill="both", expand=True, padx=20, pady=20)

--- a/src/model/bot.py
+++ b/src/model/bot.py
@@ -87,7 +87,7 @@ class Bot(ABC):
     progress: float = 0
     status = BotStatus.STOPPED
     thread: BotThread = None
-    api = API()
+    pushbullet = API()
 
     @abstractmethod
     def __init__(self, game_title, bot_title, description, window: Window):
@@ -159,7 +159,7 @@ class Bot(ABC):
             self.reset_progress()
             self.set_status(BotStatus.RUNNING)
             if settings.get("pushbullet_api_key"):
-                self.api.set_token(settings.get("pushbullet_api_key"))
+                self.pushbullet.set_token(settings.get("pushbullet_api_key"))
             self.thread = BotThread(target=self.main_loop)
             self.thread.setDaemon(True)
             self.thread.start()
@@ -605,4 +605,4 @@ class Bot(ABC):
 
     def send_notification(self, title, body):
         if settings.get("pushbullet_api_key"):
-            self.api.send_note(title, body)
+            self.pushbullet.send_note(title, body)

--- a/src/model/bot.py
+++ b/src/model/bot.py
@@ -11,6 +11,7 @@ import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Union
+from pushbullet import API
 
 import customtkinter
 import numpy as np
@@ -23,6 +24,8 @@ import utilities.debug as debug
 import utilities.imagesearch as imsearch
 import utilities.ocr as ocr
 import utilities.random_util as rd
+import utilities.settings as settings
+
 from utilities.geometry import Point, Rectangle
 from utilities.mouse import Mouse
 from utilities.options_builder import OptionsBuilder
@@ -84,6 +87,7 @@ class Bot(ABC):
     progress: float = 0
     status = BotStatus.STOPPED
     thread: BotThread = None
+    api = API()
 
     @abstractmethod
     def __init__(self, game_title, bot_title, description, window: Window):
@@ -154,6 +158,8 @@ class Bot(ABC):
                 return
             self.reset_progress()
             self.set_status(BotStatus.RUNNING)
+            if settings.get("pushbullet_api_key"):
+                self.api.set_token(settings.get("pushbullet_api_key"))
             self.thread = BotThread(target=self.main_loop)
             self.thread.setDaemon(True)
             self.thread.start()
@@ -596,3 +602,7 @@ class Bot(ABC):
             self.mouse.click()
         else:
             self.log_msg("Run is already off.")
+
+    def send_notification(self, title, body):
+        if settings.get("pushbullet_api_key"):
+            self.api.send_note(title, body)

--- a/src/view/settings_view.py
+++ b/src/view/settings_view.py
@@ -69,6 +69,18 @@ class SettingsView(customtkinter.CTkFrame):
         )
         widget_list.append(self.lbl_keybind_note)
 
+        # Pushbullet config
+        self.frame_pushbullet = customtkinter.CTkFrame(master=self)
+        self.frame_keybinds.columnconfigure(0, weight=0)  # lbl label
+        self.frame_keybinds.columnconfigure(1, weight=1)  # text input
+        self.pushbullet_label = customtkinter.CTkLabel(master=self.frame_pushbullet, text="Pushbullet API Key:")
+        self.pushbullet_label.grid(row=0, column=0)
+        self.pushbullet_widget = customtkinter.CTkEntry(master=self.frame_pushbullet, corner_radius=5, placeholder_text="Enter API Key...")
+        if settings.get("pushbullet_api_key"):
+            self.pushbullet_widget.insert(0, settings.get("pushbullet_api_key"))
+        self.pushbullet_widget.grid(row=0, column=1)
+        widget_list.append(self.frame_pushbullet)
+
         # Grid layout
         self.num_of_widgets = len(widget_list)
         for i in range(self.num_of_widgets):
@@ -130,6 +142,7 @@ class SettingsView(customtkinter.CTkFrame):
             settings.set("keybind", settings.default_keybind)
             print("No keybind set, using default keybind.")
         settings.set("keybind", self.current_keys)
+        settings.set("pushbullet_api_key", self.pushbullet_widget.get().strip())
         print(f"Keybind set to {settings.keybind_to_text(self.current_keys)}")
         print("Please restart OSBC for changes to take effect.")
         window.destroy()


### PR DESCRIPTION
This allows a call to the send_notification function of bot.py so that updates can be sent to whatever device you have recieving pushbullet notifications. For example, a good use case would be for bot developers add a notification hook when we have run out of runes or resources when high alching.

The API key is configured via settings and is unique to the bot user. The pushbullet API key (Access token) can be found at https://www.pushbullet.com/#settings/account.

If the API key is not configured, bot scripts will continue as normal.