### PR TITLE
Update color.py

### DIFF
--- a/src/utilities/color.py
+++ b/src/utilities/color.py
@@ -60,3 +60,9 @@ OFF_YELLOW = Color([190, 190, 0], [255, 255, 120])
 """Colors for use with minimap orb text"""
 ORB_GREEN = Color([0, 255, 0], [255, 255, 0])
 ORB_RED = Color([255, 0, 0], [255, 255, 0])
+
+"""Colors for use with chatbox text"""
+TEXT_RED = Color([239,16,32])
+TEXT_GREEN = Color([0,95,0])
+TEXT_BLUE = Color([1,1,255])
+TEXT_BLACK = Color([1,1,0])


### PR DESCRIPTION
Updated color.py to add RGB values for different text colors in the chat box.

Previously BLACK and BLUE worked but RED and GREEN were not being picked up by find_text(). So I extracted the RGBs from the the chat for black, blue, red and green and made a section for the global variable to be used.