### PR TITLE
Update mouse.py, added ability to set custom mouse speed by developers

### DIFF
--- a/src/utilities/mouse.py
+++ b/src/utilities/mouse.py
@@ -15,13 +15,7 @@ from utilities.random_util import truncated_normal_sample
 class Mouse:
     click_delay = True
     custom_speeds = {}
-    DEFAULT_SPEEDS = {
-        "slowest": (85, 100),
-        "slow": (65, 80),
-        "medium": (45, 60),
-        "fast": (20, 40),
-        "fastest": (10, 15)
-    }
+    DEFAULT_SPEEDS = {"slowest": (85, 100), "slow": (65, 80), "medium": (45, 60), "fast": (20, 40), "fastest": (10, 15)}
 
     def move_to(self, destination: tuple, **kwargs):
         """
@@ -190,7 +184,7 @@ class Mouse:
         self.custom_speeds[speed_name] = (min_val, max_val)
 
     def __get_speed(self, speed_name: str):
-        return self.custom_speeds.get(speed_name, None)
+        return self.custom_speeds.get(speed_name)
 
 if __name__ == "__main__":
     mouse = Mouse()


### PR DESCRIPTION
I find the fastest mousespeed defined inside the project too slow for certain tasks, ie dropping items or swapping gear.

With these changes developers will be able to add their custom mouse speed. In your botscript you can register the custom mouse speed with:
`self.mouse.register_mouse_speed("custom", 4, 8)`

Now you can use mousespeed "custom" in your script, just like you would do normally:
`self.mouse.move_to(item.random_point(), mouseSpeed="custom")`

You can define multiple custom mousespeeds
`self.mouse.register_mouse_speed("super_duper_fast", 2, 4)`
`self.mouse.register_mouse_speed("super_duper_slow", 200, 400)`

`self.mouse.move_to(item.random_point(), mouseSpeed="super_duper_fast")`
`self.mouse.move_to(item.random_point(), mouseSpeed="super_duper_slow")`

Value errors are raised when the developers input is below 2, and if min_val is higher then max_val.

All default mouseSpeeds will work the same as they used to before.
`self.mouse.move_to(item.random_point(), mouseSpeed="slowest")`
`self.mouse.move_to(item.random_point(), mouseSpeed="slow")`
`self.mouse.move_to(item.random_point(), mouseSpeed="fast")`
`self.mouse.move_to(item.random_point(), mouseSpeed="fastest")`
